### PR TITLE
Github action build & push docker image

### DIFF
--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -1,0 +1,34 @@
+env:
+  IMAGE_NODE: elrond-go-node-devnet
+  REGISTRY_HOSTNAME: elrondnetwork
+
+name: Build Docker image & push
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-docker-image:
+    strategy:
+      matrix:
+        runs-on: [ubuntu-latest]
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+
+      - name: "Build image"
+        run: |
+          TAG_VERSION=${{ steps.get_version.outputs.VERSION }}
+          cd ${GITHUB_WORKSPACE} && docker build -t "${REGISTRY_HOSTNAME}/${IMAGE_NODE}:${TAG_VERSION}" -f ./docker/Dockerfile .
+      - name: "Push image"
+        run: |
+          docker login --username lucianmincu --password ${{ secrets.DOCKERHUB_TOKEN }}
+          TAG_VERSION=${{ steps.get_version.outputs.VERSION }}
+          docker push "${REGISTRY_HOSTNAME}/${IMAGE_NODE}:${TAG_VERSION}"


### PR DESCRIPTION
Added a Github action that will build a new docker image on every release.
The new image will be pushed on the Dockerhub with the name `elrond-go-node-devnet:{tag}`